### PR TITLE
Fix: Corrected CSS for invisible login form

### DIFF
--- a/Views/Account/Login.cshtml
+++ b/Views/Account/Login.cshtml
@@ -50,5 +50,11 @@
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js"></script>
+    <script>
+        // Add fade-in class to body on load
+        document.addEventListener('DOMContentLoaded', function () {
+            document.body.classList.add('fade-in');
+        });
+    </script>
 </body>
 </html>

--- a/wwwroot/css/modern.css
+++ b/wwwroot/css/modern.css
@@ -98,18 +98,18 @@ body {
 }
 
 .login-card .card-header h2 {
-    color: var(--text-color-dark);
+    color: var(--text-color);
     font-weight: 700;
 }
 
 .login-card .form-control {
-    background: rgba(255, 255, 255, 0.2);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    color: var(--text-color-dark);
+    background: rgba(255, 255, 255, 0.8);
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    color: var(--text-color);
 }
 
 .login-card .form-control::placeholder {
-    color: rgba(255, 255, 255, 0.7);
+    color: rgba(0, 0, 0, 0.4);
 }
 
 .login-card .btn-primary {


### PR DESCRIPTION
The login form was invisible due to low-contrast colors and an incorrect opacity transition.

- Modified `wwwroot/css/modern.css` to use darker text and more opaque backgrounds for form elements, improving visibility.
- Added a JavaScript snippet to `Views/Account/Login.cshtml` to apply the `fade-in` class to the body on page load, ensuring the page becomes visible.