### PR TITLE
Refactor Task Cloning Logic

### DIFF
--- a/Controllers/ProjectsController.cs
+++ b/Controllers/ProjectsController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using TaskManagementApp.Models;
 using TaskManagementApp.Services.Interfaces;
@@ -227,7 +228,8 @@ namespace TaskManagementApp.Controllers
             {
                 try
                 {
-                    var newProject = await _templateService.CloneProjectAsync(id, viewModel.Name, viewModel.Description, excludedTaskIds);
+                    var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+                    var newProject = await _templateService.CloneProjectAsync(id, viewModel.Name, viewModel.Description, userId, excludedTaskIds);
                     TempData["SuccessMessage"] = "Project cloned successfully!";
                     return RedirectToAction(nameof(Details), new { id = newProject.Id });
                 }

--- a/Controllers/TasksController.cs
+++ b/Controllers/TasksController.cs
@@ -218,7 +218,7 @@ namespace TaskManagementApp.Controllers
             try
             {
                 var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-                var newTaskId = await _taskService.CloneTaskAsync(id, null, userId);
+                var newTaskId = await _taskService.CloneTaskTreeAsync(id, null, userId);
                 TempData["SuccessMessage"] = "Task cloned successfully! You can now edit the task structure.";
                 return RedirectToAction(nameof(EditTree), new { id = newTaskId });
             }

--- a/Services/Interfaces/ITaskService.cs
+++ b/Services/Interfaces/ITaskService.cs
@@ -69,14 +69,15 @@ namespace TaskManagementApp.Services.Interfaces
         Task<EditTaskViewModel?> GetEditTaskViewModelAsync(int id);
 
         /// <summary>
-        /// Deep clones a task and its sub-tasks.
+        /// Deep clones a task and its sub-tasks using a memory-mapping strategy.
         /// </summary>
         /// <param name="sourceTaskId">The ID of the task to clone.</param>
         /// <param name="targetProjectId">Optional target project ID. If null, the source project ID is used.</param>
         /// <param name="userId">The ID of the user performing the clone.</param>
         /// <param name="newParentId">Optional new parent task ID for the cloned task.</param>
+        /// <param name="excludedTaskIds">Optional list of task IDs to exclude from the clone.</param>
         /// <returns>The ID of the newly created task.</returns>
-        Task<int> CloneTaskAsync(int sourceTaskId, int? targetProjectId, string userId, int? newParentId = null);
+        Task<int> CloneTaskTreeAsync(int sourceTaskId, int? targetProjectId, string userId, int? newParentId = null, List<int>? excludedTaskIds = null);
 
         /// <summary>
         /// Retrieves the task tree for editing.

--- a/Services/Interfaces/ITemplateService.cs
+++ b/Services/Interfaces/ITemplateService.cs
@@ -6,6 +6,6 @@ namespace TaskManagementApp.Services.Interfaces
     public interface ITemplateService
     {
         Task<Project> GenerateProjectFromTemplateAsync(int templateId, Project targetProject);
-        Task<Project> CloneProjectAsync(int sourceProjectId, string newProjectName, string newProjectDescription, List<int>? excludedTaskIds = null);
+        Task<Project> CloneProjectAsync(int sourceProjectId, string newProjectName, string newProjectDescription, string userId, List<int>? excludedTaskIds = null);
     }
 }


### PR DESCRIPTION
This PR refactors the task cloning logic to eliminate duplication and ensure data consistency.

Key changes:
- Added `CloneTaskTreeAsync` to `ITaskService` and `TaskService`. This method uses `AsNoTracking` to load the task tree and recursively maps it to new `TaskItem` objects in memory, resetting IDs and metadata, before saving in a single transaction.
- Removed duplicate cloning logic (`CloneTaskRecursiveAsync`, `CreateTaskFromTaskRecursive`) from `TaskService` and `TemplateService`.
- Refactored `TemplateService.CloneProjectAsync` to iterate through root tasks and call `_taskService.CloneTaskTreeAsync` for each, supporting the `excludedTaskIds` filter.
- Updated `TasksController.Clone` to use `CloneTaskTreeAsync` and redirect to `EditTree`.
- Updated `ProjectsController.Clone` to pass the authenticated `userId` to `TemplateService`, ensuring proper attribution of cloned tasks.
- Updated `ITemplateService` and `TemplateService` to accept `userId` for project cloning.

---
*PR created automatically by Jules for task [7652468400716345211](https://jules.google.com/task/7652468400716345211) started by @dzidzis94*