### PR TITLE
Fix recursive task UI duplication and refactor Tasks/Details view

### DIFF
--- a/Controllers/TasksController.cs
+++ b/Controllers/TasksController.cs
@@ -58,7 +58,7 @@ namespace TaskManagementApp.Controllers
                 return NotFound();
             }
 
-            var task = await _taskService.GetTaskByIdAsync(id.Value);
+            var task = await _taskService.GetTaskDetailsAsync(id.Value);
             if (task == null)
             {
                 return NotFound();

--- a/Services/Interfaces/ITaskService.cs
+++ b/Services/Interfaces/ITaskService.cs
@@ -25,6 +25,13 @@ namespace TaskManagementApp.Services.Interfaces
         Task<TaskItem?> GetTaskByIdAsync(int id);
 
         /// <summary>
+        /// Retrieves detailed information about a task, including its sub-tasks and completions, mapped to a view model.
+        /// </summary>
+        /// <param name="id">The ID of the task to retrieve.</param>
+        /// <returns>The detailed task summary view model, or null if not found.</returns>
+        Task<TaskSummaryViewModel?> GetTaskDetailsAsync(int id);
+
+        /// <summary>
         /// Creates a new task based on the provided view model.
         /// </summary>
         /// <param name="model">The view model containing the data for the new task.</param>

--- a/ViewModels/TaskSummaryViewModel.cs
+++ b/ViewModels/TaskSummaryViewModel.cs
@@ -15,13 +15,22 @@ namespace TaskManagementApp.ViewModels
         public TaskPriority Priority { get; set; }
         public DateTime? DueDate { get; set; }
         public int? ProjectId { get; set; }
+        public string ProjectName { get; set; }
         public int? ParentTaskId { get; set; }
         public DateTime CreatedAt { get; set; }
+        public string CreatedByUserName { get; set; }
         public List<string> AssignedUserNames { get; set; } = new List<string>();
         public List<string> AssignedUserIds { get; set; } = new List<string>();
         public List<string> CompletedUserNames { get; set; } = new List<string>();
         public List<string> CompletedUserIds { get; set; } = new List<string>();
+        public List<TaskCompletionViewModel> Completions { get; set; } = new List<TaskCompletionViewModel>();
         public double CompletionPercentage { get; set; }
         public List<TaskSummaryViewModel> SubTasks { get; set; } = new List<TaskSummaryViewModel>();
+    }
+
+    public class TaskCompletionViewModel
+    {
+        public string UserName { get; set; }
+        public DateTime CompletionDate { get; set; }
     }
 }

--- a/Views/Shared/_TaskList.cshtml
+++ b/Views/Shared/_TaskList.cshtml
@@ -5,6 +5,10 @@
     {
         foreach (var task in Model)
         {
+            if (task.ParentTaskId != null && Model.Any(x => x.Id == task.ParentTaskId))
+            {
+                continue;
+            }
             @await Html.PartialAsync("_TaskCardPartial", task)
         }
     }

--- a/Views/Tasks/Details.cshtml
+++ b/Views/Tasks/Details.cshtml
@@ -1,12 +1,12 @@
-@model TaskManagementApp.Models.TaskItem
+@model TaskManagementApp.ViewModels.TaskSummaryViewModel
 @using Microsoft.AspNetCore.Identity
 @inject UserManager<ApplicationUser> UserManager
 
 @{
     ViewData["Title"] = "Task Details";
     var currentUserId = UserManager.GetUserId(User);
-    var isAssigned = Model.TaskAssignments.Any(ta => ta.UserId == currentUserId);
-    var hasCompleted = Model.TaskCompletions.Any(tc => tc.UserId == currentUserId);
+    var isAssigned = Model.AssignedUserIds.Contains(currentUserId);
+    var hasCompleted = Model.CompletedUserIds.Contains(currentUserId);
     var canComplete = isAssigned && !hasCompleted;
 }
 
@@ -18,7 +18,7 @@
                 <ol class="breadcrumb bg-transparent p-0 m-0">
                     @if (Model.ProjectId.HasValue)
                     {
-                        <li class="breadcrumb-item"><a asp-controller="Projects" asp-action="Details" asp-route-id="@Model.ProjectId">@Model.Project?.Name</a></li>
+                        <li class="breadcrumb-item"><a asp-controller="Projects" asp-action="Details" asp-route-id="@Model.ProjectId">@Model.ProjectName</a></li>
                     }
                     else
                     {
@@ -68,7 +68,7 @@
                     <div class="col-md-6">
                         <div class="mb-2">
                             <strong style="color: var(--text-color);">Created by:</strong> <br>
-                            <i class="fas fa-user-edit me-2"></i> @Model.CreatedBy?.UserName
+                            <i class="fas fa-user-edit me-2"></i> @Model.CreatedByUserName
                         </div>
                         <div class="mb-2">
                             <strong style="color: var(--text-color);">Created at:</strong> <br>
@@ -98,7 +98,7 @@
                 @if (Model.SubTasks != null && Model.SubTasks.Any())
                 {
                     <div class="sub-tasks">
-                         @await Html.PartialAsync("_TaskList", Model.SubTasks.Select(MapToSummary))
+                         @await Html.PartialAsync("_TaskList", Model.SubTasks)
                     </div>
                 }
                 else
@@ -115,12 +115,12 @@
                     <h6 class="mb-0 fw-bold" style="color: var(--text-color);">Assigned Users</h6>
                 </div>
                 <ul class="list-group list-group-flush">
-                    @if (Model.TaskAssignments != null && Model.TaskAssignments.Any())
+                    @if (Model.AssignedUserNames != null && Model.AssignedUserNames.Any())
                     {
-                        @foreach (var assignment in Model.TaskAssignments)
+                        @foreach (var userName in Model.AssignedUserNames)
                         {
                             <li class="list-group-item bg-transparent" style="color: var(--text-color); border-bottom: 1px solid var(--border-color);">
-                                <i class="fas fa-user me-2 text-muted"></i> @assignment.User?.UserName
+                                <i class="fas fa-user me-2 text-muted"></i> @userName
                             </li>
                         }
                     }
@@ -136,12 +136,12 @@
                     <h6 class="mb-0 fw-bold" style="color: var(--text-color);">Completion History</h6>
                 </div>
                  <ul class="list-group list-group-flush">
-                    @if (Model.TaskCompletions != null && Model.TaskCompletions.Any())
+                    @if (Model.Completions != null && Model.Completions.Any())
                     {
-                        @foreach (var completion in Model.TaskCompletions.OrderByDescending(c => c.CompletionDate))
+                        @foreach (var completion in Model.Completions.OrderByDescending(c => c.CompletionDate))
                         {
                             <li class="list-group-item bg-transparent d-flex justify-content-between align-items-center" style="color: var(--text-color); border-bottom: 1px solid var(--border-color);">
-                                <span><i class="fas fa-check text-success me-2"></i> @completion.User?.UserName</span>
+                                <span><i class="fas fa-check text-success me-2"></i> @completion.UserName</span>
                                 <small style="color: var(--text-muted);">@completion.CompletionDate.ToString("yyyy-MM-dd HH:mm")</small>
                             </li>
                         }
@@ -155,26 +155,3 @@
         </div>
     </div>
 </div>
-
-@functions {
-    TaskManagementApp.ViewModels.TaskSummaryViewModel MapToSummary(TaskManagementApp.Models.TaskItem task)
-    {
-        return new TaskManagementApp.ViewModels.TaskSummaryViewModel
-        {
-            Id = task.Id,
-            Title = task.Title,
-            Description = task.Description,
-            Status = task.Status,
-            Priority = task.Priority,
-            DueDate = task.DueDate,
-            ProjectId = task.ProjectId,
-            ParentTaskId = task.ParentTaskId,
-            CreatedAt = task.CreatedAt,
-            AssignedUserNames = task.TaskAssignments?.Where(ta => ta.User != null).Select(ta => ta.User.UserName).ToList() ?? new List<string>(),
-            AssignedUserIds = task.TaskAssignments?.Select(ta => ta.UserId).ToList() ?? new List<string>(),
-            CompletedUserNames = task.TaskCompletions?.Where(tc => tc.User != null).Select(tc => tc.User.UserName).ToList() ?? new List<string>(),
-            CompletedUserIds = task.TaskCompletions?.Select(tc => tc.UserId).ToList() ?? new List<string>(),
-            SubTasks = task.SubTasks?.Select(MapToSummary).ToList() ?? new List<TaskManagementApp.ViewModels.TaskSummaryViewModel>()
-        };
-    }
-}


### PR DESCRIPTION
This PR addresses the UI duplication issue in recursive task lists and refactors the Task Details view.

Changes:
1.  **Duplicate Filtering**: Added logic to `Views/Shared/_TaskList.cshtml` to skip rendering a task if its parent is also present in the current list. This resolves the issue where child tasks were rendered twice (once inside the parent and once as a standalone item).
2.  **Task Details Refactoring**:
    *   Updated `Views/Tasks/Details.cshtml` to use `TaskSummaryViewModel` instead of `TaskItem`.
    *   Moved the mapping logic from the View to the Service layer (`TaskService.GetTaskDetailsAsync`).
    *   Enhanced `TaskSummaryViewModel` with properties for `ProjectName`, `CreatedByUserName`, and a new `Completions` list to support the details view requirements.
3.  **Service Layer Updates**:
    *   Added `GetTaskDetailsAsync` to `ITaskService` and `TaskService`. This method fetches the task with hierarchy and maps it to the ViewModel, ensuring subtasks are distinct to handle any potential duplicate references in the entity graph.
    *   Updated `GetTasksAsync` to populate the new `ProjectName` and `CreatedByUserName` properties.
4.  **Controller Updates**:
    *   Updated `TasksController.Details` to use the new service method.

---
*PR created automatically by Jules for task [8049321435648400247](https://jules.google.com/task/8049321435648400247) started by @dzidzis94*